### PR TITLE
[SR-3477] Whitelist `develop`, `master` and `main` branches from branch naming check

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,9 @@ Toolkit.run(
         if (head_branch.match(/^release\/.+/)) {
           return true
         }
+        if (head_branch.match(/^(develop|master|main)$/)) {
+          return true
+        }
         // check the branch matches PROJECT-1234 or PROJECT_1234 somewhere
         if (!projects.some(project => head_branch.match(createProjectRegex(project)))) {
           tools.log('PR branch ' + head_branch + ' does not contain an approved project with format PROJECT-1234 or PROJECT_1234')


### PR DESCRIPTION
## Summary
- Adds `develop`, `master`, and `main` to the branch bypass list in the `check_branch` step
- These long-lived branches were failing the linting check since only `dependabot/` and `release/` were whitelisted

## Context
Fixes https://github.com/kantox/kantox-flow/actions/runs/27928410646/job/82638627762 — PRs opened from `master` (e.g. kantox-flow#23605) were failing the "Ensure correct branch naming" step.

## Test plan
- [ ] Open a PR from `master` → verify the branch check passes
- [ ] Open a PR from a feature branch without a ticket ref → verify it still fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)